### PR TITLE
Introduce Mod Breaking Bug

### DIFF
--- a/src/main/java/net/pedroksl/advanced_ae/common/definitions/AAEBlocks.java
+++ b/src/main/java/net/pedroksl/advanced_ae/common/definitions/AAEBlocks.java
@@ -27,7 +27,7 @@ import appeng.core.definitions.BlockDefinition;
 import appeng.core.definitions.ItemDefinition;
 import appeng.decorative.AEDecorativeBlock;
 
-public final class AAEBlocks {
+public final class AAEBlock {
     public static final DeferredRegister.Blocks DR = DeferredRegister.createBlocks(AdvancedAE.MOD_ID);
 
     private static final List<BlockDefinition<?>> BLOCKS = new ArrayList<>();


### PR DESCRIPTION
Adds a typo that breaks references to `AAEBlocks` class