### PR TITLE
Copy/paste typos in AAEConfig.java / advanced_ae-common.toml?

### DIFF
--- a/src/main/java/net/pedroksl/advanced_ae/common/definitions/AAEConfig.java
+++ b/src/main/java/net/pedroksl/advanced_ae/common/definitions/AAEConfig.java
@@ -170,7 +170,7 @@ public class AAEConfig {
                     8,
                     4,
                     16,
-                    "Define the maximum amount of Accelerators per Quantum Computer Multiblock.");
+                    "Define the amount of Threads per Quantum Computer Accelerator.");
             quantumComputerMaxMultiThreaders = define(
                     builder,
                     "quantumComputerMaxMultiThreaders",


### PR DESCRIPTION
I noticed what looks like a couple of small copy/paste typos in `src/main/java/net/pedroksl/advanced_ae/common/definitions/AAEConfig.java`:

```
$> grep 'multi threaders' config/advanced_ae-common.toml |head -n2
        #Define the maximum amount of multi threaders per Quantum Computer Multiblock.
        #Define the maximum amount of multi threaders per Quantum Computer Multiblock.
```

Assuming I'm actually right and these *are* typos, here's a tiny PR to fix those comments.

Oh, and thanks for the awesome mod! :grin: