### PR TITLE
Guard quantum armor client-only logic

### DIFF
--- a/src/main/java/net/pedroksl/advanced_ae/client/AAEClient.java
+++ b/src/main/java/net/pedroksl/advanced_ae/client/AAEClient.java
@@ -16,6 +16,7 @@ import net.neoforged.neoforge.client.gui.ConfigurationScreen;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
 import net.neoforged.neoforge.common.NeoForge;
 import net.pedroksl.advanced_ae.AdvancedAE;
+import net.pedroksl.advanced_ae.client.events.AAEPlayerClientEvents;
 import net.pedroksl.advanced_ae.client.gui.*;
 import net.pedroksl.advanced_ae.client.renderer.AAECraftingUnitModelProvider;
 import net.pedroksl.advanced_ae.client.renderer.ReactionChamberTESR;
@@ -58,6 +59,8 @@ public class AAEClient extends AdvancedAE {
         eventBus.addListener(this::registerHotkeys);
 
         INSTANCE = this;
+
+        NeoForge.EVENT_BUS.register(AAEPlayerClientEvents.class);
 
         NeoForge.EVENT_BUS.addListener((ClientTickEvent.Post e) -> {
             AAEHotkeys.INSTANCE.checkHotkeys();

--- a/src/main/java/net/pedroksl/advanced_ae/client/events/AAEPlayerClientEvents.java
+++ b/src/main/java/net/pedroksl/advanced_ae/client/events/AAEPlayerClientEvents.java
@@ -1,0 +1,92 @@
+package net.pedroksl.advanced_ae.client.events;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.client.event.RenderPlayerEvent;
+import net.neoforged.neoforge.event.tick.PlayerTickEvent;
+import net.neoforged.neoforge.network.PacketDistributor;
+import net.pedroksl.advanced_ae.common.items.armors.QuantumBoots;
+import net.pedroksl.advanced_ae.common.items.armors.QuantumChestplate;
+import net.pedroksl.advanced_ae.common.items.armors.QuantumHelmet;
+import net.pedroksl.advanced_ae.common.items.armors.QuantumLeggings;
+import net.pedroksl.advanced_ae.common.items.upgrades.UpgradeType;
+import net.pedroksl.advanced_ae.events.AAEPlayerEvents;
+import net.pedroksl.advanced_ae.network.packet.KeysPressedPacket;
+
+public class AAEPlayerClientEvents {
+
+    @SubscribeEvent
+    public static void playerRender(RenderPlayerEvent.Pre event) {
+        Player player = event.getEntity();
+        var renderer = event.getRenderer();
+        var model = renderer.getModel();
+
+        ItemStack helmetStack = player.getItemBySlot(EquipmentSlot.HEAD);
+        if (helmetStack.getItem() instanceof QuantumHelmet item && item.isVisible(helmetStack)) {
+            model.hat.visible = false;
+        }
+
+        ItemStack chestStack = player.getItemBySlot(EquipmentSlot.CHEST);
+        if (chestStack.getItem() instanceof QuantumChestplate item && item.isVisible(chestStack)) {
+            model.leftSleeve.visible = false;
+            model.rightSleeve.visible = false;
+            model.jacket.visible = false;
+
+            model.leftArm.visible = false;
+            model.rightArm.visible = false;
+        }
+
+        ItemStack leggingsStack = player.getItemBySlot(EquipmentSlot.LEGS);
+        ItemStack bootsStack = player.getItemBySlot(EquipmentSlot.FEET);
+        if (leggingsStack.getItem() instanceof QuantumLeggings item && item.isVisible(leggingsStack)) {
+            model.leftPants.visible = false;
+            model.rightPants.visible = false;
+
+            if (bootsStack.getItem() instanceof QuantumBoots item2 && item2.isVisible(bootsStack)) {
+                model.leftLeg.visible = false;
+                model.rightLeg.visible = false;
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public static void playerTick(PlayerTickEvent.Post event) {
+        Player player = event.getEntity();
+        if (!player.level().isClientSide()) {
+            return;
+        }
+
+        var options = Minecraft.getInstance().options;
+
+        ItemStack bootStack = player.getItemBySlot(EquipmentSlot.FEET);
+        if (bootStack.getItem() instanceof QuantumBoots boots
+                && boots.isUpgradeEnabledAndPowered(bootStack, UpgradeType.FLIGHT_DRIFT)) {
+            var noKey = !options.keyUp.isDown()
+                    && !options.keyRight.isDown()
+                    && !options.keyDown.isDown()
+                    && !options.keyLeft.isDown();
+            if (player.getPersistentData().getBoolean(AAEPlayerEvents.NO_KEY_DATA) != noKey) {
+                PacketDistributor.sendToServer(new KeysPressedPacket(AAEPlayerEvents.NO_KEY_DATA, noKey));
+                player.getPersistentData().putBoolean(AAEPlayerEvents.NO_KEY_DATA, noKey);
+            }
+        }
+
+        ItemStack chestStack = player.getItemBySlot(EquipmentSlot.CHEST);
+        if (chestStack.getItem() instanceof QuantumChestplate) {
+            var downKey = options.keyShift.isDown();
+            if (player.getPersistentData().getBoolean(AAEPlayerEvents.DOWN_KEY_DATA) != downKey) {
+                PacketDistributor.sendToServer(new KeysPressedPacket(AAEPlayerEvents.DOWN_KEY_DATA, downKey));
+                player.getPersistentData().putBoolean(AAEPlayerEvents.DOWN_KEY_DATA, downKey);
+            }
+
+            var upKey = options.keyJump.isDown();
+            if (player.getPersistentData().getBoolean(AAEPlayerEvents.UP_KEY_DATA) != upKey) {
+                PacketDistributor.sendToServer(new KeysPressedPacket(AAEPlayerEvents.UP_KEY_DATA, upKey));
+                player.getPersistentData().putBoolean(AAEPlayerEvents.UP_KEY_DATA, upKey);
+            }
+        }
+    }
+}

--- a/src/main/java/net/pedroksl/advanced_ae/common/items/armors/QuantumArmorBase.java
+++ b/src/main/java/net/pedroksl/advanced_ae/common/items/armors/QuantumArmorBase.java
@@ -92,9 +92,11 @@ public class QuantumArmorBase extends PoweredItem implements GeoItem, IMenuItem,
     public void setTintColor(Player player, ItemStack stack, int color) {
         stack.set(LibComponents.TINT_COLOR_TAG, color);
 
-        var renderer = getRenderer(player, stack);
-        if (renderer != null) {
-            renderer.setTintColor(color);
+        if (player.level().isClientSide()) {
+            var renderer = getRenderer(player, stack);
+            if (renderer != null) {
+                renderer.setTintColor(color);
+            }
         }
     }
 
@@ -102,6 +104,7 @@ public class QuantumArmorBase extends PoweredItem implements GeoItem, IMenuItem,
         return !stack.getOrDefault(AAEComponents.UPGRADE_TOGGLE.get(UpgradeType.CAMO), false);
     }
 
+    @OnlyIn(Dist.CLIENT)
     private void updateVisibility(Player player, ItemStack stack) {
         var visible = isVisible(stack);
         var renderer = getRenderer(player, stack);
@@ -112,7 +115,7 @@ public class QuantumArmorBase extends PoweredItem implements GeoItem, IMenuItem,
 
     @Override
     public final void inventoryTick(ItemStack stack, Level level, Entity entity, int slotId, boolean isSelected) {
-        if (entity instanceof Player player) {
+        if (level.isClientSide() && entity instanceof Player player) {
             updateVisibility(player, stack);
         }
 
@@ -121,6 +124,8 @@ public class QuantumArmorBase extends PoweredItem implements GeoItem, IMenuItem,
 
     protected void tick(ItemStack stack, Level level, Entity entity, int slotId) {}
 
+    @OnlyIn(Dist.CLIENT)
+    @Nullable
     protected QuantumArmorRenderer getRenderer(Player player, ItemStack stack) {
         var renderProvider = getRenderProvider();
         if (renderProvider instanceof GeoRenderProvider provider) {
@@ -221,6 +226,7 @@ public class QuantumArmorBase extends PoweredItem implements GeoItem, IMenuItem,
     }
 
     @Override
+    @OnlyIn(Dist.CLIENT)
     public void createGeoRenderer(Consumer<GeoRenderProvider> consumer) {
         consumer.accept(new GeoRenderProvider() {
             private QuantumArmorRenderer renderer;

--- a/src/main/java/net/pedroksl/advanced_ae/common/items/armors/QuantumChestplate.java
+++ b/src/main/java/net/pedroksl/advanced_ae/common/items/armors/QuantumChestplate.java
@@ -17,6 +17,8 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.network.PacketDistributor;
 import net.pedroksl.advanced_ae.client.renderer.QuantumArmorRenderer;
 import net.pedroksl.advanced_ae.common.definitions.AAEComponents;
@@ -73,13 +75,14 @@ public class QuantumChestplate extends QuantumArmorBase implements GeoItem, ISub
                     tickUpgrades(level, player, stack);
                 }
 
-                if (isVisible(stack)) {
+                if (player.level().isClientSide() && isVisible(stack)) {
                     toggleBoneVisibilities(stack, player);
                 }
             }
         }
     }
 
+    @OnlyIn(Dist.CLIENT)
     private void toggleBoneVisibilities(ItemStack stack, Player player) {
         var renderer = getRenderer(player, stack);
         if (renderer != null) {

--- a/src/main/java/net/pedroksl/advanced_ae/events/AAEPlayerEvents.java
+++ b/src/main/java/net/pedroksl/advanced_ae/events/AAEPlayerEvents.java
@@ -1,6 +1,5 @@
 package net.pedroksl.advanced_ae.events;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -14,7 +13,6 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.neoforge.client.event.RenderPlayerEvent;
 import net.neoforged.neoforge.common.NeoForgeMod;
 import net.neoforged.neoforge.event.ItemAttributeModifierEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
@@ -25,7 +23,6 @@ import net.pedroksl.advanced_ae.common.definitions.AAEComponents;
 import net.pedroksl.advanced_ae.common.items.armors.*;
 import net.pedroksl.advanced_ae.common.items.upgrades.UpgradeType;
 import net.pedroksl.advanced_ae.network.packet.ItemTrackingPacket;
-import net.pedroksl.advanced_ae.network.packet.KeysPressedPacket;
 import net.pedroksl.advanced_ae.xmod.Addons;
 import net.pedroksl.advanced_ae.xmod.apoth.ApoEnchPlugin;
 
@@ -94,42 +91,6 @@ public class AAEPlayerEvents {
                     if (value < 1) {
                         event.setNewSpeed(event.getOriginalSpeed() / value);
                     }
-                }
-            }
-        }
-    }
-
-    @SubscribeEvent
-    public static void playerRender(RenderPlayerEvent.Pre event) {
-        Player player = event.getEntity();
-        if (!(player instanceof ServerPlayer)) {
-            var renderer = event.getRenderer();
-            var model = renderer.getModel();
-
-            ItemStack helmetStack = player.getItemBySlot(EquipmentSlot.HEAD);
-            if (helmetStack.getItem() instanceof QuantumHelmet item && item.isVisible(helmetStack)) {
-                model.hat.visible = false;
-            }
-
-            ItemStack chestStack = player.getItemBySlot(EquipmentSlot.CHEST);
-            if (chestStack.getItem() instanceof QuantumChestplate item && item.isVisible(chestStack)) {
-                model.leftSleeve.visible = false;
-                model.rightSleeve.visible = false;
-                model.jacket.visible = false;
-
-                model.leftArm.visible = false;
-                model.rightArm.visible = false;
-            }
-
-            ItemStack leggingsStack = player.getItemBySlot(EquipmentSlot.LEGS);
-            ItemStack bootsStack = player.getItemBySlot(EquipmentSlot.FEET);
-            if (leggingsStack.getItem() instanceof QuantumLeggings item && item.isVisible(leggingsStack)) {
-                model.leftPants.visible = false;
-                model.rightPants.visible = false;
-
-                if (bootsStack.getItem() instanceof QuantumBoots item2 && item2.isVisible(bootsStack)) {
-                    model.leftLeg.visible = false;
-                    model.rightLeg.visible = false;
                 }
             }
         }
@@ -219,46 +180,6 @@ public class AAEPlayerEvents {
                             / 25f;
                     var direction = upKey ? 1 : -1;
                     player.moveRelative(value, new Vec3(0, direction, 0));
-                }
-            }
-        }
-    }
-
-    @SubscribeEvent
-    public static void playerTick(PlayerTickEvent.Post event) {
-        Player player = event.getEntity();
-        if (!(player instanceof ServerPlayer)) {
-            ItemStack bootStack = player.getItemBySlot(EquipmentSlot.FEET);
-            if (bootStack.getItem() instanceof QuantumBoots boots) {
-                if (boots.isUpgradeEnabledAndPowered(bootStack, UpgradeType.FLIGHT_DRIFT)) {
-                    var options = Minecraft.getInstance().options;
-                    var noKey = !options.keyUp.isDown()
-                            && !options.keyRight.isDown()
-                            && !options.keyDown.isDown()
-                            && !options.keyLeft.isDown();
-                    if (player.getPersistentData().getBoolean(NO_KEY_DATA) != noKey) {
-                        // Send packet to server if data on player is different
-                        PacketDistributor.sendToServer(new KeysPressedPacket(NO_KEY_DATA, noKey));
-                        player.getPersistentData().putBoolean(NO_KEY_DATA, noKey);
-                    }
-                }
-            }
-
-            ItemStack chestStack = player.getItemBySlot(EquipmentSlot.CHEST);
-            if (chestStack.getItem() instanceof QuantumChestplate) {
-                var options = Minecraft.getInstance().options;
-                var downKey = options.keyShift.isDown();
-                if (player.getPersistentData().getBoolean(DOWN_KEY_DATA) != downKey) {
-                    // Send packet to server if data on player is different
-                    PacketDistributor.sendToServer(new KeysPressedPacket(DOWN_KEY_DATA, downKey));
-                    player.getPersistentData().putBoolean(DOWN_KEY_DATA, downKey);
-                }
-
-                var upKey = options.keyJump.isDown();
-                if (player.getPersistentData().getBoolean(UP_KEY_DATA) != upKey) {
-                    // Send packet to server if data on player is different
-                    PacketDistributor.sendToServer(new KeysPressedPacket(UP_KEY_DATA, upKey));
-                    player.getPersistentData().putBoolean(UP_KEY_DATA, upKey);
                 }
             }
         }

--- a/src/main/java/net/pedroksl/advanced_ae/network/packet/AdvPatternEncoderPacket.java
+++ b/src/main/java/net/pedroksl/advanced_ae/network/packet/AdvPatternEncoderPacket.java
@@ -10,6 +10,8 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.world.entity.player.Player;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
 import net.pedroksl.advanced_ae.client.gui.AdvPatternEncoderScreen;
 
 import appeng.api.stacks.AEKey;
@@ -56,6 +58,7 @@ public record AdvPatternEncoderPacket(LinkedHashMap<AEKey, Direction> dirMap) im
     }
 
     @Override
+    @OnlyIn(Dist.CLIENT)
     public void handleOnClient(Player player) {
         if (Minecraft.getInstance().screen instanceof AdvPatternEncoderScreen encoderGui) {
             encoderGui.update(this.dirMap);

--- a/src/main/java/net/pedroksl/advanced_ae/network/packet/PatternConfigServerUpdatePacket.java
+++ b/src/main/java/net/pedroksl/advanced_ae/network/packet/PatternConfigServerUpdatePacket.java
@@ -11,6 +11,8 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.entity.player.Player;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
 import net.pedroksl.advanced_ae.client.gui.QuantumCrafterConfigPatternScreen;
 
 import appeng.api.stacks.AEKey;
@@ -64,6 +66,7 @@ public record PatternConfigServerUpdatePacket(LinkedHashMap<AEKey, Long> inputs,
     }
 
     @Override
+    @OnlyIn(Dist.CLIENT)
     public void handleOnClient(Player player) {
         if (Minecraft.getInstance().screen instanceof QuantumCrafterConfigPatternScreen screen) {
             screen.update(this.inputs, this.output);

--- a/src/main/java/net/pedroksl/advanced_ae/network/packet/PatternsUpdatePacket.java
+++ b/src/main/java/net/pedroksl/advanced_ae/network/packet/PatternsUpdatePacket.java
@@ -7,6 +7,8 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.entity.player.Player;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
 import net.pedroksl.advanced_ae.client.gui.QuantumCrafterScreen;
 
 import appeng.core.network.ClientboundPacket;
@@ -60,6 +62,7 @@ public record PatternsUpdatePacket(List<Boolean> invalidPatterns, List<Boolean> 
     }
 
     @Override
+    @OnlyIn(Dist.CLIENT)
     public void handleOnClient(Player player) {
         if (Minecraft.getInstance().screen instanceof QuantumCrafterScreen screen) {
             screen.updateInvalidButtons(this.invalidPatterns);

--- a/src/main/java/net/pedroksl/advanced_ae/network/packet/quantumarmor/QuantumArmorUpgradeStatePacket.java
+++ b/src/main/java/net/pedroksl/advanced_ae/network/packet/quantumarmor/QuantumArmorUpgradeStatePacket.java
@@ -7,6 +7,8 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.entity.player.Player;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
 import net.pedroksl.advanced_ae.client.gui.QuantumArmorConfigScreen;
 import net.pedroksl.advanced_ae.client.widgets.UpgradeState;
 
@@ -31,6 +33,7 @@ public record QuantumArmorUpgradeStatePacket(int selectedIndex, List<UpgradeStat
     }
 
     @Override
+    @OnlyIn(Dist.CLIENT)
     public void handleOnClient(Player player) {
         if (Minecraft.getInstance().screen instanceof QuantumArmorConfigScreen screen) {
             screen.refreshList(selectedIndex, states);


### PR DESCRIPTION
Equipping quantum armor triggered net.minecraft.client.* references on a dedicated server (renderers, key handling, packet handlers), causing repeated RuntimeDistCleaner warnings and crashes whenever the server processed a client-only update.

Fix: Keep all renderer/key/GUI logic in client‑only code paths: guard visibility/tint updates with level.isClientSide(), move render/key events into a client event class, annotate client packet handlers with @OnlyIn(Dist.CLIENT), and register the client listener only in AAEClient.