### PR TITLE
Fix crafting CPU inventory loss on chunk unload

### DIFF
--- a/src/main/java/net/pedroksl/advanced_ae/common/entities/AdvCraftingBlockEntity.java
+++ b/src/main/java/net/pedroksl/advanced_ae/common/entities/AdvCraftingBlockEntity.java
@@ -115,6 +115,17 @@ public class AdvCraftingBlockEntity extends AENetworkedBlockEntity
 
     public void updateStatus(AdvCraftingCPUCluster c) {
         if (this.cluster != null && this.cluster != c) {
+            // Persist the cluster's crafting state before releasing the reference.
+            // During chunk unload, disconnect() → destroy() → updateStatus(null)
+            // runs BEFORE the chunk is saved to disk. If we null the cluster here,
+            // saveAdditional() will skip writing the inventory and in-progress crafting
+            // jobs are permanently lost. Saving to previousState ensures the data
+            // survives for the subsequent saveAdditional() call.
+            if (c == null && this.isCoreBlock()) {
+                var data = new CompoundTag();
+                this.cluster.writeToNBT(data, this.level.registryAccess());
+                this.setPreviousState(data);
+            }
             this.cluster.breakCluster();
         }
 
@@ -179,8 +190,15 @@ public class AdvCraftingBlockEntity extends AENetworkedBlockEntity
     public void saveAdditional(CompoundTag data, HolderLookup.Provider registries) {
         super.saveAdditional(data, registries);
         data.putBoolean("core", this.isCoreBlock());
-        if (this.isCoreBlock() && this.cluster != null) {
-            this.cluster.writeToNBT(data, registries);
+        if (this.isCoreBlock()) {
+            if (this.cluster != null) {
+                this.cluster.writeToNBT(data, registries);
+            } else if (this.previousState != null) {
+                // Cluster was destroyed (chunk unload / server shutdown) before save.
+                // Restore the snapshot taken in updateStatus() so the inventory and
+                // in-progress crafting jobs survive the round-trip.
+                data.merge(this.previousState);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Fixes AdvCraftingBlockEntity losing in-progress crafting inventory on chunk unload / server shutdown
- Same root cause and fix as applied to base AE2's CraftingBlockEntity (AE2 commit `13fa5e39f`)
- During chunk unload, `disconnect()` → `destroy()` → `updateStatus(null)` nulls the cluster reference BEFORE `saveAdditional()` runs, causing the inventory to be silently dropped

## Changes

- `updateStatus()`: snapshots cluster crafting state into `previousState` before releasing the cluster reference
- `saveAdditional()`: falls back to `previousState` when cluster is null, preserving inventory data through save/load cycles

## Test plan

- [x] Set up a quantum crafting CPU with an active multi-step crafting job
- [x] Shut down the server while the job is in progress
- [x] Restart — verify the crafting inventory is preserved and the job resumes
- [x] Verify chunk unload (moving far away) also preserves the inventory

🤖 Generated with [Claude Code](https://claude.com/claude-code)