### PR TITLE
fix(reaction-chamber): proxy bucket handler to fluidInv to fix silent fluid loss

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,5 +1,0 @@
-# CodeGraph data files — local to each machine, not for committing.
-# Ignore everything in .codegraph/ except this file itself, so transient
-# files (the database, daemon.pid, sockets, logs) never show up in git.
-*
-!.gitignore

--- a/src/main/java/net/pedroksl/advanced_ae/common/entities/ReactionChamberEntity.java
+++ b/src/main/java/net/pedroksl/advanced_ae/common/entities/ReactionChamberEntity.java
@@ -751,19 +751,57 @@ public class ReactionChamberEntity extends AENetworkedPoweredBlockEntity
         }
     }
 
+    /**
+     * caller: ReactionChamberBlock.useItemOn.
+     * Parent's stacks[] is unused; data is proxied directly to fluidInv to avoid the
+     * two-storage mismatch where super.insert(1, ...)/super.extract(0, ...) wrote
+     * to FluidStacksResourceHandler.stacks[1]/[0] while fluidInv stayed empty
+     *
+     * @author howxu &lt;dev@howxu.cn&gt;
+     */
     private class ReactionChamberResourceHandler extends FluidStacksResourceHandler {
         public ReactionChamberResourceHandler() {
-            super(fluidInv.size(), MAX_TANK_CAPACITY);
+            // size=1 keeps NeoForge 21.x Objects.checkIndex(0, 1) passing
+            // capacity=0 makes any accidental super.insert return 0.
+            super(1, 0);
         }
 
+        // slot 1 input interaction
         @Override
         public int insert(int index, FluidResource resource, int amount, TransactionContext transaction) {
-            return super.insert(1, resource, amount, transaction);
+            if (resource.isEmpty() || amount <= 0) return 0;
+            var key = AEFluidKey.of(resource);
+            if (key == null) return 0;
+
+            var existing = fluidInv.getStack(1);
+            // Reject type mismatch to avoid overwriting a different fluid
+            if (existing != null && !existing.what().equals(key)) return 0;
+            long current = existing != null ? existing.amount() : 0;
+            long inserted = Math.min(amount, MAX_TANK_CAPACITY - current);
+            if (inserted <= 0) return 0;
+
+            fluidInv.setStack(1, new GenericStack(key, current + inserted));
+            return (int) inserted;
         }
 
+        // slot 0 output interaction
         @Override
         public int extract(int index, FluidResource resource, int amount, TransactionContext transaction) {
-            return super.extract(0, resource, amount, transaction);
+            if (resource.isEmpty() || amount <= 0) return 0;
+            var key = AEFluidKey.of(resource);
+            if (key == null) return 0;
+
+            var existing = fluidInv.getStack(0);
+            if (existing == null || !existing.what().equals(key)) return 0;
+
+            long extracted = Math.min(amount, existing.amount());
+            long remaining = existing.amount() - extracted;
+            if (remaining <= 0) {
+                fluidInv.setStack(0, null);
+            } else {
+                fluidInv.setStack(0, new GenericStack(key, remaining));
+            }
+            return (int) extracted;
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes bucket interactions on the Reaction Chamber silently dropping fluid because the handler wrote to `FluidStacksResourceHandler.stacks[]` while the rest of the chamber (GUI, auto-export, crafting tick) reads from `fluidInv`.

Close #313 

## Cause

`ReactionChamberResourceHandler` at `ReactionChamberEntity.java:754` extended `FluidStacksResourceHandler` and overrode:

```java
public int insert(...) { return super.insert(1, ...); }
public int extract(...) { return super.extract(0, ...); }
```

super.insert(1, ...) writes to the parent's FluidStack[] stacks[1], not to fluidInv.stacks[1]. The reaction chamber's tickingRequest, pushOutResult, hasCraftWork, and getFluidStack all read fluidInv directly, so the two stores never synchronized.

## Fix
- insert / extract proxy directly to fluidInv at slot 1 (input) and slot 0 (output), dropping the dependence on the parent's stacks[].
- Type mismatch in insert is rejected early to avoid overwriting a different fluid already in slot 1.
- Parent constructed with super(1, 0): size=1 keeps NeoForge 21.x's Objects.checkIndex in getResource / getAmountAsLong from throwing capacity=0 makes any accidental super.insert return 0.

## Tests
No unit tests needed, just test in game directly.

## One more thing
I more suggest that use **ResourceHandler[FluidResource]** if convinient, just drop the stacks array, but I think it may cause some long term problem, so the solution now is almost best.