### PR TITLE
Implement `clearContent` on AdvPatternProviderPart

### DIFF
--- a/src/main/java/net/pedroksl/advanced_ae/common/parts/AdvPatternProviderPart.java
+++ b/src/main/java/net/pedroksl/advanced_ae/common/parts/AdvPatternProviderPart.java
@@ -98,6 +98,12 @@ public class AdvPatternProviderPart extends AEBasePart implements AdvPatternProv
     }
 
     @Override
+    public void clearContent() {
+        super.clearContent();
+        this.logic.clearContent();
+    }
+
+    @Override
     public float getCableConnectionLength(AECableType cable) {
         return 4.0F;
     }


### PR DESCRIPTION
Patches the dupe glitch with Create: Aeronautics Swivel Bearing

## Approach

Implement clearContent the same way AE2 itself and ExtendedAE do

https://github.com/AppliedEnergistics/Applied-Energistics-2/blob/45f315517ea346efc0babd02c85c6b9d32dc8acf/src/main/java/appeng/parts/crafting/PatternProviderPart.java#L104-L108
https://github.com/GlodBlock/ExtendedAE/blob/3776bc854458301bbcc9a44a8238d70a0e3dc00d/src/main/java/com/glodblock/github/extendedae/common/parts/PartExPatternProvider.java#L97-L101

## Before

[Screencast From 2026-08-03 18-03-29.webm](https://github.com/user-attachments/assets/b6fbb3a5-872b-403a-9abc-e122ce021b35)

## After

[Screencast From 2026-08-03 17-57-36.webm](https://github.com/user-attachments/assets/4d511930-09a0-488b-ae8e-f9700e1be8d1)
