### PR TITLE
Auto Stock: don't scan the whole network inventory every tick

### DIFF
--- a/src/main/java/net/pedroksl/advanced_ae/common/items/upgrades/UpgradeCards.java
+++ b/src/main/java/net/pedroksl/advanced_ae/common/items/upgrades/UpgradeCards.java
@@ -203,7 +203,6 @@ public class UpgradeCards {
                 var filter = stack.getOrDefault(
                         AAEComponents.UPGRADE_FILTER.get(UpgradeType.AUTO_STOCK), new ArrayList<GenericStack>());
                 boolean didSomething = false;
-                var inventory = storage.getInventory().getAvailableStacks();
                 for (var genStack : filter) {
                     if (genStack.what() instanceof AEItemKey itemKey) {
                         var desiredAmount = genStack.amount();
@@ -217,7 +216,7 @@ public class UpgradeCards {
                             }
                         }
                         var amountDelta = desiredAmount - currentAmount;
-                        if (amountDelta > 0 && inventory.get(itemKey) > 0) {
+                        if (amountDelta > 0) {
                             long extracted = storage.getInventory()
                                     .extract(
                                             genStack.what(),


### PR DESCRIPTION
## Summary

The Quantum Helmet Auto Stock upgrade calls `getAvailableStacks()` on the
linked network every tick, before checking whether any filtered item is
actually missing. On a network with many item types this rebuilds a full
`KeyCounter` 20 times per second for every player wearing the helmet, even
with an empty filter.

## Cause

`UpgradeCards.autoStock` fetches the full inventory once per tick, but the
only use is the `inventory.get(itemKey) > 0` guard in front of `extract()`.
`extract()` already returns 0 when the network has nothing, so the guard is
redundant.

## Fix

Drop the `getAvailableStacks()` call and the guard. Behaviour is unchanged:
extraction still only runs when the player is below the desired amount, and
the extracted amount is whatever the network can actually provide.

## Measurements

Dedicated server, All the Mons 1.2.0 (NeoForge 21.1.248, AE2 19.2.17,
AdvancedAE 1.6.12-1.21.1), one player, spark profiler, 60 s each:

| Auto Stock | `autoStock` main-thread time |
|---|---|
| enabled, empty filter | 1.16 ms/tick |
| enabled, 1 filter entry | 1.09 ms/tick |
| disabled | 0 |

Related: #237 reports high tick time with quantum armour, but that one
traces to a different root cause (slot-change listeners), so this PR does
not close it.

## Notes

The same code exists on `main`; happy to open a second PR there if you'd
like.

Disclosure: the profiling and the initial diagnosis were done with an AI
coding assistant (Claude). I reviewed the change and measured it on my own
server (numbers above).
